### PR TITLE
chore: add Python support updates to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,8 +33,8 @@ bytecode
 
 Install bytecode: ``python3 -m pip install bytecode``. It requires Python 3.6
 or newer. The latest release that supports Python 3.5 is 0.12.0. For Python 2.7
-support install, `dead-bytecode <https://github.com/p403n1x87/dead-bytecode>`_
-instead.
+support, have a look at  `dead-bytecode
+<https://github.com/p403n1x87/dead-bytecode>`_ instead.
 
 Example executing ``print('Hello World!')``:
 

--- a/README.rst
+++ b/README.rst
@@ -31,8 +31,10 @@ bytecode
 * `Download latest bytecode release at the Python Cheeseshop (PyPI)
   <https://pypi.python.org/pypi/bytecode>`_
 
-Install bytecode: ``python3 -m pip install bytecode``. It requires Python 3.5
-or newer.
+Install bytecode: ``python3 -m pip install bytecode``. It requires Python 3.6
+or newer. The latest release that supports Python 3.5 is 0.12.0. For Python 2.7
+support install, `dead-bytecode <https://github.com/p403n1x87/dead-bytecode>`_
+instead.
 
 Example executing ``print('Hello World!')``:
 


### PR DESCRIPTION
Future releases of this package drop support for versions of Python earlier than 3.6. Also inform that the latest version to support Python 3.5 is 0.12.0 and add a link to the Python 2 backport.