### PR TITLE
Change Copyright to: Contributors to the bytecode project

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,5 @@
 The MIT License (MIT)
-Copyright (c) 2016 Red Hat.
+Copyright Contributors to the bytecode project.
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -44,7 +44,7 @@ master_doc = "index"
 
 # General information about the project.
 project = u"bytecode"
-copyright = u"2016-2021, Victor Stinner"
+copyright = u"Contributors to the bytecode project"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Sorry, I blindly copied the COPYING file from one of my past project
without paying attention to the copyright line.

See: https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/