### PR TITLE
Make test imports relative to tests package

### DIFF
--- a/bytecode/tests/test_bytecode.py
+++ b/bytecode/tests/test_bytecode.py
@@ -3,7 +3,7 @@ import sys
 import textwrap
 import unittest
 from bytecode import Label, Instr, FreeVar, Bytecode, SetLineno, ConcreteInstr
-from bytecode.tests import TestCase, get_code
+from . import TestCase, get_code
 
 
 class BytecodeTests(TestCase):

--- a/bytecode/tests/test_cfg.py
+++ b/bytecode/tests/test_cfg.py
@@ -13,7 +13,7 @@ from bytecode import (
     ControlFlowGraph,
 )
 from bytecode.concrete import OFFSET_AS_INSTRUCTION
-from bytecode.tests import disassemble as _disassemble, TestCase
+from . import disassemble as _disassemble, TestCase
 
 
 def disassemble(

--- a/bytecode/tests/test_code.py
+++ b/bytecode/tests/test_code.py
@@ -1,7 +1,7 @@
 import unittest
 
 from bytecode import ConcreteBytecode, Bytecode, ControlFlowGraph
-from bytecode.tests import get_code
+from . import get_code
 
 
 class CodeTests(unittest.TestCase):

--- a/bytecode/tests/test_concrete.py
+++ b/bytecode/tests/test_concrete.py
@@ -18,7 +18,7 @@ from bytecode import (
     SetLineno,
 )
 from bytecode.concrete import OFFSET_AS_INSTRUCTION
-from bytecode.tests import TestCase, get_code
+from . import TestCase, get_code
 
 
 class ConcreteInstrTests(TestCase):
@@ -619,7 +619,7 @@ class ConcreteFromCodeTests(TestCase):
 
     def test_extended_arg_make_function(self):
         if (3, 9) <= sys.version_info < (3, 10):
-            from bytecode.tests.util_annotation import get_code as get_code_future
+            from .util_annotation import get_code as get_code_future
 
             code_obj = get_code_future(
                 """
@@ -1504,7 +1504,7 @@ class BytecodeToConcreteTests(TestCase):
         self.assertEqual(f(), (obj1, obj2, obj3, obj4))
 
     def test_packing_lines(self):
-        from bytecode.tests.long_lines_example import long_lines
+        from .long_lines_example import long_lines
         import dis
 
         line_starts = list(dis.findlinestarts(long_lines.__code__))

--- a/bytecode/tests/test_instr.py
+++ b/bytecode/tests/test_instr.py
@@ -11,7 +11,7 @@ from bytecode import (
     SetLineno,
     Compare,
 )
-from bytecode.tests import TestCase
+from . import TestCase
 
 
 class SetLinenoTests(TestCase):

--- a/bytecode/tests/test_misc.py
+++ b/bytecode/tests/test_misc.py
@@ -8,7 +8,7 @@ import unittest
 import bytecode
 from bytecode import Label, Instr, Bytecode, BasicBlock, ControlFlowGraph
 from bytecode.concrete import OFFSET_AS_INSTRUCTION
-from bytecode.tests import disassemble
+from . import disassemble
 
 
 class DumpCodeTests(unittest.TestCase):

--- a/bytecode/tests/test_peephole_opt.py
+++ b/bytecode/tests/test_peephole_opt.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 from bytecode import Label, Instr, Compare, Bytecode, ControlFlowGraph
 from bytecode import peephole_opt
-from bytecode.tests import TestCase, dump_bytecode
+from . import TestCase, dump_bytecode
 from unittest import mock
 
 


### PR DESCRIPTION
The test suite currently has lots of imports of the form `from bytecode.tests import ...`.  This means that the tests can only be run when they are present together with the bytecode package itself, not independently.  This patch replaces these imports with relative imports: `from . import ...`.  All of the tests continue to run successfully with this patch when run in the current way, but they also work when the `tests` directory is copied elsewhere and the `tests` directory is removed from the installed package (for the tests are not needed for the bytecode package to work).  The only test which does not work when the tests are run on the installed package is `test_version`, because that requires the presence of `setup.py`, but that is a minor issue.