### PR TITLE
fix: exclude EXC_MATCH from Compare enum in Python>=3.9

### DIFF
--- a/bytecode/instr.py
+++ b/bytecode/instr.py
@@ -19,7 +19,8 @@ class Compare(enum.IntEnum):
     NOT_IN = 7
     IS = 8
     IS_NOT = 9
-    EXC_MATCH = 10
+    if sys.version_info < (3, 9):
+        EXC_MATCH = 10
 
 
 UNSET = object()

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,15 @@
 ChangeLog
 =========
 
+23/02/2022: Version 0.13.1
+--------------------------
+
+Bugfixes:
+
+- Removed ``EXC_MATCH`` from the ``Compare`` enumeration starting with Python
+  3.9. The new ``JUMP_IF_NOT_EXC_MATCH`` opcode should be used instead.
+
+
 04/10/2021: Version 0.13.0
 --------------------------
 


### PR DESCRIPTION
Python 3.9 introduced `JUMP_IF_NOT_EXC_MATCH` and removed the exception match from the set of compare operations. This change ensures that `EXC_MATCH` is not exported by the Compare enum from Python 3.9 onward. The new opcode should be used instead.

Fixes #93.