### PR TITLE
fix: exclude IS, IS_NOT, IN, NOT_IN from Compare enum in Python>=3.9

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -12,6 +12,10 @@ Bugfixes:
 - Removed ``EXC_MATCH`` from the ``Compare`` enumeration starting with Python
   3.9. The new ``JUMP_IF_NOT_EXC_MATCH`` opcode should be used instead.
 
+- Removed ``IN``, ``NOT_IN``, ``IS``, ``NOT_IS`` from the ``Compare``
+  enumeration starting with Python 3.9. The new ``CONTAINS_OP`` and ``IS_OP``
+  opcodes should be used instead.
+
 Maintenance:
 
 - Make the install process PEP517 compliant PR #97

--- a/src/bytecode/instr.py
+++ b/src/bytecode/instr.py
@@ -15,11 +15,11 @@ class Compare(enum.IntEnum):
     NE = 3
     GT = 4
     GE = 5
-    IN = 6
-    NOT_IN = 7
-    IS = 8
-    IS_NOT = 9
     if sys.version_info < (3, 9):
+        IN = 6
+        NOT_IN = 7
+        IS = 8
+        IS_NOT = 9
         EXC_MATCH = 10
 
 

--- a/src/bytecode/peephole_opt.py
+++ b/src/bytecode/peephole_opt.py
@@ -15,12 +15,15 @@ JUMPS_ON_TRUE = frozenset(
     )
 )
 
-NOT_COMPARE = {
-    Compare.IN: Compare.NOT_IN,
-    Compare.NOT_IN: Compare.IN,
-    Compare.IS: Compare.IS_NOT,
-    Compare.IS_NOT: Compare.IS,
-}
+if sys.version_info < (3, 9):
+    NOT_COMPARE = {
+        Compare.IN: Compare.NOT_IN,
+        Compare.NOT_IN: Compare.IN,
+        Compare.IS: Compare.IS_NOT,
+        Compare.IS_NOT: Compare.IS,
+    }
+else:
+    NOT_COMPARE = {}
 
 MAX_SIZE = 20
 
@@ -240,9 +243,14 @@ class PeepholeOptimizer:
         if instr.arg > len(self.const_stack):
             return
 
-        next_instr = self.get_next_instr("COMPARE_OP")
-        if next_instr is None or next_instr.arg not in (Compare.IN, Compare.NOT_IN):
-            return
+        if sys.version_info < (3, 9):
+            next_instr = self.get_next_instr("COMPARE_OP")
+            if next_instr is None or next_instr.arg not in (Compare.IN, Compare.NOT_IN):
+                return
+        else:
+            next_instr = self.get_next_instr("CONTAINS_OP")
+            if next_instr is None:
+                return
 
         self.replace_container_of_consts(instr, container_type)
         return True

--- a/tests/test_instr.py
+++ b/tests/test_instr.py
@@ -356,5 +356,27 @@ class InstrTests(TestCase):
         self.assertIs(f()(), mutable_datum)
 
 
+class CompareTests(TestCase):
+    def test_compare_ops(self):
+        from bytecode import Bytecode, Instr
+
+        def f():
+            pass
+
+        params = zip(iter(Compare), (True, True, False, True, False, False))
+        for cmp, expected in params:
+            with self.subTest():
+                f.__code__ = Bytecode(
+                    [
+                        Instr("LOAD_CONST", 24),
+                        Instr("LOAD_CONST", 42),
+                        Instr("COMPARE_OP", cmp),
+                        Instr("RETURN_VALUE"),
+                    ]
+                ).to_code()
+
+                self.assertIs(f(), expected)
+
+
 if __name__ == "__main__":
     unittest.main()  # pragma: no cover

--- a/tests/test_peephole_opt.py
+++ b/tests/test_peephole_opt.py
@@ -257,6 +257,12 @@ class Tests(TestCase):
 
     def test_build_list(self):
         # test = x in [1, 2, 3]
+        compare_instr = (
+            Instr("COMPARE_OP", Compare.IN)
+            if sys.version_info < (3, 9)
+            else Instr("CONTAINS_OP", 0)
+        )
+
         code = Bytecode(
             [
                 Instr("LOAD_NAME", "x"),
@@ -264,7 +270,7 @@ class Tests(TestCase):
                 Instr("LOAD_CONST", 2),
                 Instr("LOAD_CONST", 3),
                 Instr("BUILD_LIST", 3),
-                Instr("COMPARE_OP", Compare.IN),
+                compare_instr,
                 Instr("STORE_NAME", "test"),
             ]
         )
@@ -273,7 +279,7 @@ class Tests(TestCase):
             code,
             Instr("LOAD_NAME", "x"),
             Instr("LOAD_CONST", (1, 2, 3)),
-            Instr("COMPARE_OP", Compare.IN),
+            compare_instr,
             Instr("STORE_NAME", "test"),
         )
 
@@ -381,6 +387,12 @@ class Tests(TestCase):
 
     def test_build_set(self):
         # test = x in {1, 2, 3}
+        compare_instr = (
+            Instr("COMPARE_OP", Compare.IN)
+            if sys.version_info < (3, 9)
+            else Instr("CONTAINS_OP", 0)
+        )
+
         code = Bytecode(
             [
                 Instr("LOAD_NAME", "x"),
@@ -388,7 +400,7 @@ class Tests(TestCase):
                 Instr("LOAD_CONST", 2),
                 Instr("LOAD_CONST", 3),
                 Instr("BUILD_SET", 3),
-                Instr("COMPARE_OP", Compare.IN),
+                compare_instr,
                 Instr("STORE_NAME", "test"),
             ]
         )
@@ -397,10 +409,11 @@ class Tests(TestCase):
             code,
             Instr("LOAD_NAME", "x"),
             Instr("LOAD_CONST", frozenset((1, 2, 3))),
-            Instr("COMPARE_OP", Compare.IN),
+            compare_instr,
             Instr("STORE_NAME", "test"),
         )
 
+    @unittest.skipIf(sys.version_info >= (3, 9), "enums not available in Python>=3.9")
     def test_compare_op_unary_not(self):
         for op, not_op in (
             (Compare.IN, Compare.NOT_IN),  # in => not in


### PR DESCRIPTION
Python 3.9 introduced the new opcodes `CONTAINS_OP` and `IS_OP` to perform `in` and `is` comparisons, instead of dedicated values for the argument to the `COMPARE_OP` instruction.

Fixes #101.