### PR TITLE
Correctly ignore ellipses in overloads

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -18,4 +18,4 @@ exclude_lines =
     pass
 
     # Don't complain about ellipsis in overload
-    ...
+    \.\.\.


### PR DESCRIPTION
Follow-up for 6e6e38c2dc33bd16a1a4c787c6d5f82b6221b600

`exclude_lines` is a list of regexes, so `...` unescaped will actually exclude most lines from coverage analysis.
At the moment codecov is getting empty coverage data because of this exclusion rule.