### PR TITLE
Allow fusing TryBegin with an unknown stack size when converting from CFG to bytecode

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,16 @@
 ChangeLog
 =========
 
+unreleased: Version 0.14.2
+--------------------------
+
+Bugfixes:
+
+- allow to convert a CFG, for which stack sizes have not been computed, to Bytecode
+  even in the presence of mergeable TryBegin/TryEnd  PR #120
+- remove spurious TryEnd leftover when going from CFG to Bytecode  PR #120
+
+
 2023-04-04: Version 0.14.1
 --------------------------
 

--- a/src/bytecode/cfg.py
+++ b/src/bytecode/cfg.py
@@ -1007,6 +1007,11 @@ class ControlFlowGraph(_bytecode.BaseBytecode):
                         # Only keep the first seen TryEnd matching a TryBegin
                         assert isinstance(new, TryEnd)
                         if instr.entry in seen_try_end:
+                            # If we encounter a previously seen TryEnd, it
+                            # makes no sense to remember the last try end
+                            # since cancelling out a TryBegin/TryEnd pair does
+                            # not make sense in this case.
+                            last_try_end = None
                             continue
                         seen_try_end.add(instr.entry)
                         new.entry = try_begins[instr.entry]


### PR DESCRIPTION
I have seen this causing a bug when analyzing a CFG whose dump is:
```
block1:
    RESUME 0
    LOAD_CONST 0
    LOAD_CONST None
    IMPORT_NAME 'logging'
    STORE_NAME 'logging'
    PUSH_NULL
    LOAD_NAME 'logging'
    LOAD_ATTR 'getLogger'
    LOAD_NAME '__name__'
    PRECALL 1
    CALL 1
    STORE_NAME 'log'
    NOP
    TryBegin 0 -> <block2> [0]
      LOAD_CONST 0
      LOAD_CONST None
      IMPORT_NAME 'backend_1'
      STORE_NAME 'backend_1'
      LOAD_CONST True
      STORE_NAME 'backend_1_available'
    TryEnd (0)
    JUMP_FORWARD <block7>

block2:
    TryBegin 1 -> <block6> [0] last_i
      PUSH_EXC_INFO
      LOAD_NAME 'ImportError'
      CHECK_EXC_MATCH
      POP_JUMP_FORWARD_IF_FALSE <block5>
      -> block3

block3:
      STORE_NAME 'e'
    TryEnd (1)
    TryBegin 2 -> <block4> [0] last_i
      LOAD_NAME 'log'
      LOAD_METHOD 'exception'
      LOAD_NAME 'e'
      PRECALL 1
      CALL 1
      POP_TOP
      LOAD_CONST False
      STORE_NAME 'backend_1_available'
    TryEnd (2)
    POP_EXCEPT
    LOAD_CONST None
    STORE_NAME 'e'
    DELETE_NAME 'e'
    JUMP_FORWARD <block7>

block4:
    TryBegin 3 -> <block6> [0] last_i
      LOAD_CONST None
      STORE_NAME 'e'
      DELETE_NAME 'e'
      RERAISE 1
    TryEnd (3)

block5:
    TryEnd (1)
    TryBegin 4 -> <block6> [0] last_i
      RERAISE 0
    TryEnd (4)

block6:
    COPY 3
    POP_EXCEPT
    RERAISE 1

block7:
    NOP
```

The attempt to fuse the TryBegin 3 and 4 failed because we have no size for any at the point of the analysis where it happens. This should be allowed. Allowing this however can lead to a buggy situation translate with a double TryEnd for a single TryBegin which is wrong.