### PR TITLE
chore: handle LOAD_METHOD opcode in CPython 3.12

### DIFF
--- a/src/bytecode/concrete.py
+++ b/src/bytecode/concrete.py
@@ -1143,6 +1143,17 @@ class _ConvertBytecodeToConcrete:
         free_instrs: List[int] = []
 
         for instr in self.bytecode:
+            if sys.version_info >= (3, 12) and isinstance(instr, Instr):
+                if instr.name == "LOAD_METHOD":
+                    # The LOAD_METHOD opcode has become a pseudo-instruction in
+                    # Python 3.12
+                    instr = Instr(
+                        "LOAD_ATTR",
+                        (True, instr.arg),
+                        lineno=instr.lineno,
+                        location=instr.location,
+                    )
+
             # Enforce proper use of CACHE opcode on Python 3.11+ by checking we get the
             # number we expect or directly generate the needed ones.
             if isinstance(instr, Instr) and instr.name == "CACHE":

--- a/src/bytecode/instr.py
+++ b/src/bytecode/instr.py
@@ -805,6 +805,9 @@ class Instr(BaseInstr[InstrArg]):
 
         elif opcode in _opcode.haslocal or opcode in _opcode.hasname:
             if name in BITFLAG_INSTRUCTIONS:
+                if isinstance(arg, str):
+                    # Assume the bitflag is not set
+                    arg = (False, arg)
                 if not (
                     isinstance(arg, tuple)
                     and len(arg) == 2

--- a/tests/test_instr.py
+++ b/tests/test_instr.py
@@ -191,7 +191,6 @@ class InstrTests(TestCase):
 
         # Instructions using a bitflag in their oparg
         for name in BITFLAG_INSTRUCTIONS:
-            self.assertRaises(TypeError, Instr, name, "arg")
             self.assertRaises(TypeError, Instr, name, ("arg",))
             self.assertRaises(TypeError, Instr, name, ("", "arg"))
             self.assertRaises(TypeError, Instr, name, (False, 1))
@@ -449,6 +448,26 @@ class InstrTests(TestCase):
         f.__code__ = f_code.to_code()
 
         self.assertIs(f()(), mutable_datum)
+
+    def test_load_method(self):
+        from bytecode import Bytecode, Instr
+
+        class Foo:
+            def bar(self):
+                return 42
+
+        foo = Foo()
+
+        abs_code = Bytecode(
+            [
+                Instr("LOAD_CONST", foo),
+                Instr("LOAD_METHOD", "bar"),
+                Instr("BUILD_TUPLE", 2),
+                Instr("RETURN_VALUE"),
+            ]
+        )
+
+        self.assertEqual(eval(abs_code.to_code()), (Foo.bar, foo))
 
 
 class CompareTests(TestCase):


### PR DESCRIPTION
Allow handling the `LOAD_METHOD` pseudo-instruction in CPython 3.12 by converting it to the equivalent `LOAD_ATTR` instruction.

Resolves #128.