### PR TITLE
ci: improve code round-tripping

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+2024-05-28: Version 0.15.3
+--------------------------
+
+Bugfixes:
+
+- Ensure the correct management of TryBegin blocks in CFGs. PR #1xx
+
 2024-05-28: Version 0.15.2
 --------------------------
 

--- a/src/bytecode/cfg.py
+++ b/src/bytecode/cfg.py
@@ -358,12 +358,13 @@ class _StackSizeComputer:
                 if instr.is_uncond_jump():
                     # Check for TryEnd after the final instruction which is possible
                     # TryEnd being only pseudo instructions
-                    if te := self.block.get_trailing_try_end(i):
-                        if self._current_try_begin is None:
-                            self._current_try_begin = te.entry
-                        else:
-                            # TryBegin cannot be nested
-                            assert te.entry is self._current_try_begin, (te.entry, self._current_try_begin)
+                    if self._current_try_begin is not None and (
+                        te := self.block.get_trailing_try_end(i)
+                    ):
+                        assert te.entry is self._current_try_begin, (
+                            te.entry,
+                            self._current_try_begin,
+                        )
 
                         assert isinstance(te.entry.target, BasicBlock)
                         yield from self._compute_exception_handler_stack_usage(

--- a/src/bytecode/cfg.py
+++ b/src/bytecode/cfg.py
@@ -359,8 +359,11 @@ class _StackSizeComputer:
                     # Check for TryEnd after the final instruction which is possible
                     # TryEnd being only pseudo instructions
                     if te := self.block.get_trailing_try_end(i):
-                        # TryBegin cannot be nested
-                        assert te.entry is self._current_try_begin
+                        if self._current_try_begin is None:
+                            self._current_try_begin = te.entry
+                        else:
+                            # TryBegin cannot be nested
+                            assert te.entry is self._current_try_begin, (te.entry, self._current_try_begin)
 
                         assert isinstance(te.entry.target, BasicBlock)
                         yield from self._compute_exception_handler_stack_usage(

--- a/tests/frameworks/module.py
+++ b/tests/frameworks/module.py
@@ -1,170 +1,226 @@
+import abc
 import sys
+import typing as t
+from importlib._bootstrap import _init_module_attrs
 from importlib.abc import Loader
 from importlib.machinery import ModuleSpec
 from importlib.util import find_spec
-from pathlib import Path
-from types import ModuleType
-from typing import Any, Callable, Dict, Optional, Set, Union, cast
+from types import CodeType, ModuleType
+
+TransformerType = t.Callable[[CodeType, ModuleType], CodeType]
 
 
-def origin(module):
-    # type: (ModuleType) -> str
-    """Get the origin source file of the module."""
-    try:
-        assert module.__file__ is not None
-        orig = str(Path(module.__file__).resolve())  # type: ignore[type-var]
-    except (AttributeError, TypeError):
-        # Module is probably only partially initialised, so we look at its
-        # spec instead
-        try:
-            orig = str(Path(module.__spec__.origin).resolve())  # type: ignore
-        except (AttributeError, ValueError, TypeError):
-            orig = None
-
-    if orig is not None and Path(orig).is_file():
-        if orig.endswith(".pyc"):
-            orig = orig[:-1]
-        return orig
-
-    return "<unknown origin>"
-
-
-def find_loader(fullname):
-    # type: (str) -> Optional[Loader]
+def find_loader(fullname: str) -> t.Optional[Loader]:
     return getattr(find_spec(fullname), "loader", None)
 
 
-class _ImportHookChainedLoader(Loader):
-    def __init__(self, loader):
-        # type: (Loader) -> None
+def is_namespace_spec(spec: ModuleSpec) -> bool:
+    return spec.origin is None and spec.submodule_search_locations is not None
+
+
+class _ImportHookChainedLoader:
+    def __init__(
+        self, loader: t.Optional[Loader], spec: t.Optional[ModuleSpec] = None
+    ) -> None:
         self.loader = loader
-        self.callbacks = {}  # type: Dict[Any, Callable[[ModuleType], None]]
+        self.spec = spec
 
-        # DEV: load_module is deprecated so we define it at runtime if also
-        # defined by the default loader. We also check and define for the
-        # methods that are supposed to replace the load_module functionality.
-        if hasattr(loader, "load_module"):
-            self.load_module = self._load_module  # type: ignore[assignment]
-        if hasattr(loader, "create_module"):
-            self.create_module = self._create_module  # type: ignore[assignment]
-        if hasattr(loader, "exec_module"):
-            self.exec_module = self._exec_module  # type: ignore[assignment]
+        self.callbacks: t.Dict[t.Any, t.Callable[[ModuleType], None]] = {}
+        self.transformers: t.Dict[t.Any, TransformerType] = {}
 
-    def __getattribute__(self, name):
-        if name == "__class__":
-            # Make isinstance believe that self is also an instance of
-            # type(self.loader). This is required, e.g. by some tools, like
-            # slotscheck, that can handle known loaders only.
-            return self.loader.__class__
-
-        return super(_ImportHookChainedLoader, self).__getattribute__(name)
+        # A missing loader is generally an indication of a namespace package.
+        if loader is None or hasattr(loader, "create_module"):
+            self.create_module = self._create_module
+        if loader is None or hasattr(loader, "exec_module"):
+            self.exec_module = self._exec_module
 
     def __getattr__(self, name):
         # Proxy any other attribute access to the underlying loader.
         return getattr(self.loader, name)
 
-    def add_callback(self, key, callback):
-        # type: (Any, Callable[[ModuleType], None]) -> None
+    def namespace_module(self, spec: ModuleSpec) -> ModuleType:
+        module = ModuleType(spec.name)
+        # Pretend that we do not have a loader (this would be self), to
+        # allow _init_module_attrs to create the appropriate NamespaceLoader
+        # for the namespace module.
+        spec.loader = None
+
+        _init_module_attrs(spec, module, override=True)
+
+        # Chain the loaders
+        self.loader = spec.loader
+        module.__loader__ = spec.loader = self  # type: ignore[assignment]
+
+        return module
+
+    def add_callback(
+        self, key: t.Any, callback: t.Callable[[ModuleType], None]
+    ) -> None:
         self.callbacks[key] = callback
 
-    def _load_module(self, fullname):
-        # type: (str) -> ModuleType
-        module = self.loader.load_module(fullname)
+    def add_transformer(self, key: t.Any, transformer: TransformerType) -> None:
+        self.transformers[key] = transformer
+
+    def call_back(self, module: ModuleType) -> None:
+        if module.__name__ == "pkg_resources":
+            # DEV: pkg_resources support to prevent errors such as
+            # NotImplementedError: Can't perform this operation for unregistered
+            # loader type
+            module.register_loader_type(
+                _ImportHookChainedLoader, module.DefaultProvider
+            )
+
         for callback in self.callbacks.values():
             callback(module)
+
+    def load_module(self, fullname: str) -> t.Optional[ModuleType]:
+        if self.loader is None:
+            if self.spec is None:
+                return None
+            sys.modules[self.spec.name] = module = self.namespace_module(self.spec)
+        else:
+            module = self.loader.load_module(fullname)
+
+        self.call_back(module)
 
         return module
 
     def _create_module(self, spec):
-        return self.loader.create_module(spec)
+        if self.loader is not None:
+            return self.loader.create_module(spec)
 
-    def _exec_module(self, module):
-        self.loader.exec_module(module)
-        for callback in self.callbacks.values():
-            callback(module)
+        if is_namespace_spec(spec):
+            return self.namespace_module(spec)
+
+        return None
+
+    def _exec_module(self, module: ModuleType) -> None:
+        _get_code = getattr(self.loader, "get_code", None)
+        if _get_code is not None:
+
+            def get_code(_loader, fullname):
+                code = _get_code(fullname)
+
+                for callback in self.transformers.values():
+                    code = callback(code, module)
+
+                return code
+
+            self.loader.get_code = get_code.__get__(self.loader, type(self.loader))  # type: ignore[union-attr]
+
+        if self.loader is None:
+            spec = getattr(module, "__spec__", None)
+            if spec is not None and is_namespace_spec(spec):
+                sys.modules[spec.name] = module
+        else:
+            self.loader.exec_module(module)
+
+        self.call_back(module)
 
 
-class ModuleWatchdog:
-    """Module watchdog.
-    Replace the standard ``sys.modules`` dictionary to detect when modules are
-    loaded/unloaded. This is also responsible for triggering any registered
-    import hooks.
-    Subclasses might customize the default behavior by overriding the
-    ``after_import`` method, which is triggered on every module import, once
-    the subclass is installed.
+class BaseModuleWatchdog(abc.ABC):
+    """Base module watchdog.
+
+    Invokes ``after_import`` every time a new module is imported.
     """
 
-    _instance = None  # type: Optional[ModuleWatchdog]
+    _instance: t.Optional["BaseModuleWatchdog"] = None
 
-    def __init__(self):
-        # type: () -> None
-        self._finding = set()  # type: Set[str]
+    def __init__(self) -> None:
+        self._finding: t.Set[str] = set()
 
-    def _add_to_meta_path(self):
-        # type: () -> None
+        # DEV: pkg_resources support to prevent errors such as
+        # NotImplementedError: Can't perform this operation for unregistered
+        pkg_resources = sys.modules.get("pkg_resources")
+        if pkg_resources is not None:
+            pkg_resources.register_loader_type(
+                _ImportHookChainedLoader, pkg_resources.DefaultProvider
+            )
+
+    def _add_to_meta_path(self) -> None:
         sys.meta_path.insert(0, self)  # type: ignore[arg-type]
 
     @classmethod
-    def _find_in_meta_path(cls):
-        # type: () -> Optional[int]
+    def _find_in_meta_path(cls) -> t.Optional[int]:
         for i, meta_path in enumerate(sys.meta_path):
             if type(meta_path) is cls:
                 return i
         return None
 
     @classmethod
-    def _remove_from_meta_path(cls):
-        # type: () -> None
+    def _remove_from_meta_path(cls) -> None:
         i = cls._find_in_meta_path()
-        if i is not None:
-            sys.meta_path.pop(i)
 
-    def after_import(self, module):
+        if i is None:
+            raise RuntimeError("%s is not installed" % cls.__name__)
+
+        sys.meta_path.pop(i)
+
+    def after_import(self, module: ModuleType) -> None:
         raise NotImplementedError()
 
-    def find_module(self, fullname, path=None):
-        # type: (str, Optional[str]) -> Union[ModuleWatchdog, _ImportHookChainedLoader, None]
+    def transform(self, code: CodeType, _module: ModuleType) -> CodeType:
+        return code
+
+    def find_module(
+        self, fullname: str, path: t.Optional[str] = None
+    ) -> t.Optional[Loader]:
         if fullname in self._finding:
             return None
 
         self._finding.add(fullname)
 
         try:
-            loader = find_loader(fullname)
-            if loader is not None:
-                if not isinstance(loader, _ImportHookChainedLoader):
-                    loader = _ImportHookChainedLoader(loader)
+            original_loader = find_loader(fullname)
+            if original_loader is not None:
+                loader = (
+                    _ImportHookChainedLoader(original_loader)
+                    if not isinstance(original_loader, _ImportHookChainedLoader)
+                    else original_loader
+                )
 
                 loader.add_callback(type(self), self.after_import)
+                loader.add_transformer(type(self), self.transform)
 
-                return loader
+                return t.cast(Loader, loader)
 
         finally:
             self._finding.remove(fullname)
 
         return None
 
-    def find_spec(self, fullname, path=None, target=None):
-        # type: (str, Optional[str], Optional[ModuleType]) -> Optional[ModuleSpec]
+    def find_spec(
+        self,
+        fullname: str,
+        path: t.Optional[str] = None,
+        target: t.Optional[ModuleType] = None,
+    ) -> t.Optional[ModuleSpec]:
         if fullname in self._finding:
             return None
 
         self._finding.add(fullname)
 
         try:
-            spec = find_spec(fullname)
+            try:
+                # Best effort
+                spec = find_spec(fullname)
+            except Exception:
+                return None
+
             if spec is None:
                 return None
 
             loader = getattr(spec, "loader", None)
 
-            if loader is not None:
-                if not isinstance(loader, _ImportHookChainedLoader):
-                    spec.loader = _ImportHookChainedLoader(loader)
+            if not isinstance(loader, _ImportHookChainedLoader):
+                spec.loader = t.cast(Loader, _ImportHookChainedLoader(loader, spec))
 
-                cast(_ImportHookChainedLoader, spec.loader).add_callback(
-                    type(self), self.after_import
-                )
+            t.cast(_ImportHookChainedLoader, spec.loader).add_callback(
+                type(self), self.after_import
+            )
+            t.cast(_ImportHookChainedLoader, spec.loader).add_transformer(
+                type(self), self.transform
+            )
 
             return spec
 
@@ -172,14 +228,12 @@ class ModuleWatchdog:
             self._finding.remove(fullname)
 
     @classmethod
-    def _check_installed(cls):
-        # type: () -> None
+    def _check_installed(cls) -> None:
         if not cls.is_installed():
             raise RuntimeError("%s is not installed" % cls.__name__)
 
     @classmethod
-    def install(cls):
-        # type: () -> None
+    def install(cls) -> None:
         """Install the module watchdog."""
         if cls.is_installed():
             raise RuntimeError("%s is already installed" % cls.__name__)
@@ -193,11 +247,13 @@ class ModuleWatchdog:
         return cls._instance is not None and type(cls._instance) is cls
 
     @classmethod
-    def uninstall(cls):
-        # type: () -> None
+    def uninstall(cls) -> None:
         """Uninstall the module watchdog.
+
         This will uninstall only the most recently installed instance of this
         class.
         """
         cls._check_installed()
         cls._remove_from_meta_path()
+
+        cls._instance = None

--- a/tests/frameworks/sitecustomize.py
+++ b/tests/frameworks/sitecustomize.py
@@ -1,34 +1,106 @@
+import atexit
 import dis
 import io
-import sys
-import typing as t
-from types import FunctionType, ModuleType
+from datetime import timedelta
+from time import monotonic as time
+from types import CodeType, ModuleType
 
-from function import FunctionDiscovery  # type: ignore
-from module import ModuleWatchdog  # type: ignore
+from module import BaseModuleWatchdog  # type: ignore
 
 from bytecode import Bytecode, ControlFlowGraph
 
-
-class FunctionCollector(ModuleWatchdog):
-    def after_import(self, module):
-        # type: (ModuleType) -> None
-        discovery = FunctionDiscovery(module)
-        for fname, f in discovery.items():
-            function = t.cast(FunctionType, f)
-            try:
-                byt = Bytecode.from_code(function.__code__)
-                cfg = ControlFlowGraph.from_bytecode(byt)
-                new = cfg.to_code()
-                # Check we can still disassemble the code
-                dis.dis(new, file=io.StringIO())
-            except Exception:
-                print("Failed to recompile %s" % fname)
-                dis.dis(function)
-                raise
-            else:
-                function.__code__ = new
+_original_exec = exec
 
 
-print("Collecting functions")
-FunctionCollector.install()
+class ModuleCodeCollector(BaseModuleWatchdog):
+    def __init__(self):
+        super().__init__()
+
+        # Count how many code objects we've recompiled
+        self.count = 0
+        self.stopwatch = 0
+
+        # Replace the built-in exec function with our own in the pytest globals
+        try:
+            import _pytest.assertion.rewrite as par
+
+            par.exec = self._exec
+        except ImportError:
+            pass
+
+    def transform(
+        self, code: CodeType, _module: ModuleType, root: bool = True
+    ) -> CodeType:
+        # Round-trip the code object through the library
+        try:
+            start = time()
+
+            abstract_code = Bytecode.from_code(code)
+
+            for instr in abstract_code:
+                try:
+                    if isinstance(instr.arg, CodeType):
+                        instr.arg = self.transform(instr.arg, _module, root=False)
+                except AttributeError:
+                    pass
+
+            cfg = ControlFlowGraph.from_bytecode(abstract_code)
+
+            recompiled_code = cfg.to_code()
+
+            # Check we can still disassemble the code
+            dis.dis(recompiled_code, file=io.StringIO())
+
+            if root:
+                # Only time the root code objects because of the recursion
+                self.stopwatch += time() - start
+
+            self.count += 1
+
+            return recompiled_code
+        except Exception:
+            print(f"Failed to recompile {code} from {_module}")
+            dis.dis(code)
+            raise
+
+    def after_import(self, _module: ModuleType) -> None:
+        pass
+
+    def _exec(self, _object, _globals=None, _locals=None, **kwargs):
+        # The pytest module loader doesn't implement a get_code method so we
+        # need to intercept the loading of test modules by wrapping around the
+        # exec built-in function.
+        new_object = (
+            self.transform(_object, None)
+            if isinstance(_object, CodeType) and _object.co_name == "<module>"
+            else _object
+        )
+
+        # Execute the module before calling the after_import hook
+        _original_exec(new_object, _globals, _locals, **kwargs)
+
+    @classmethod
+    def uninstall(cls) -> None:
+        # Restore the original exec function
+        try:
+            import _pytest.assertion.rewrite as par
+
+            par.exec = _original_exec
+        except ImportError:
+            pass
+
+        # Proof of work
+        print(
+            f"Recompiled {cls._instance.count} code objects in {timedelta(seconds=cls._instance.stopwatch)}"
+        )
+
+        return super().uninstall()
+
+
+print("Collecting module code objects")
+ModuleCodeCollector.install()
+
+
+@atexit.register
+def _():
+    ModuleCodeCollector.uninstall()


### PR DESCRIPTION
We improve the logic for round-trip re-compilation of code objects by listening for module code objects before they are executed. This way we can thoroughly recurse over nested code object and attain total coverage for better confidence.