### PR TITLE
fix: handle small try blocks

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,15 @@
 ChangeLog
 =========
 
+2024-05-28: Version 0.15.2
+--------------------------
+
+Bugfixes:
+
+- Ensure that empty or small (one-instruction) try blocks are handled without
+  problems when compiling and de-compiling abstract code for CPython 3.11 and
+  later. PR #145
+
 2023-10-13: Version 0.15.1
 --------------------------
 

--- a/tests/test_bytecode.py
+++ b/tests/test_bytecode.py
@@ -742,6 +742,14 @@ class BytecodeTests(TestCase):
         Bytecode.from_code(foo.__code__).to_code()
 
     def test_try_block_around_extended_arg(self):
+        """Test that we can handle small try blocks around opcodes that require
+        extended arguments.
+
+        We wrap a jump instruction between a TryBegin and TryEnd, and ensure
+        that the jump target is further away as to require an extended argument
+        for the branching instruction. We then test that we can compile and
+        de-compile the code object without issues.
+        """
         if sys.version_info < (3, 11):
             self.skipTest("Exception tables were introduced in 3.11")
 


### PR DESCRIPTION
We make sure that we can handle small (and potentially empty) try blocks. These are blocks where the end offset is smaller or at most equal to the start offset. These blocks can occur when a single instruction that requires EXTENDED_ARG opcodes is wrapped in a try block. Original code objects seem to wrap the whole instruction, including the EXTENDED_ARG opcodes. The fix in this PR wraps just the instruction, leaving the extra EXTENDED_ARG opcodes outside the try block. This might not be a problem in general, but it is perhaps not ideal.

Addresses #144.