### PR TITLE
fix(cfg): ensure correct TryBegin management

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+2024-05-28: Version 0.15.3
+--------------------------
+
+Bugfixes:
+
+- Ensure the correct management of TryBegin blocks in CFGs. PR #1xx
+
 2024-05-28: Version 0.15.2
 --------------------------
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,7 +6,7 @@ ChangeLog
 
 Bugfixes:
 
-- Ensure the correct management of TryBegin blocks in CFGs. PR #1xx
+- Ensure the correct management of TryBegin blocks in CFGs. PR #147
 
 2024-05-28: Version 0.15.2
 --------------------------

--- a/src/bytecode/cfg.py
+++ b/src/bytecode/cfg.py
@@ -358,8 +358,11 @@ class _StackSizeComputer:
                     # Check for TryEnd after the final instruction which is possible
                     # TryEnd being only pseudo instructions
                     if te := self.block.get_trailing_try_end(i):
-                        # TryBegin cannot be nested
-                        assert te.entry is self._current_try_begin
+                        if self._current_try_begin is None:
+                            self._current_try_begin = te.entry
+                        else:
+                            # TryBegin cannot be nested
+                            assert te.entry is self._current_try_begin, (te.entry, self._current_try_begin)
 
                         assert isinstance(te.entry.target, BasicBlock)
                         yield from self._compute_exception_handler_stack_usage(

--- a/src/bytecode/cfg.py
+++ b/src/bytecode/cfg.py
@@ -357,12 +357,14 @@ class _StackSizeComputer:
                 if instr.is_uncond_jump():
                     # Check for TryEnd after the final instruction which is possible
                     # TryEnd being only pseudo instructions
-                    if te := self.block.get_trailing_try_end(i):
-                        if self._current_try_begin is None:
-                            self._current_try_begin = te.entry
-                        else:
-                            # TryBegin cannot be nested
-                            assert te.entry is self._current_try_begin, (te.entry, self._current_try_begin)
+                    if self._current_try_begin is not None and (
+                        te := self.block.get_trailing_try_end(i)
+                    ):
+                        # TryBegin cannot be nested
+                        assert te.entry is self._current_try_begin, (
+                            te.entry,
+                            self._current_try_begin,
+                        )
 
                         assert isinstance(te.entry.target, BasicBlock)
                         yield from self._compute_exception_handler_stack_usage(


### PR DESCRIPTION
We make sure that the TryBegin blocks are managed correctly in CFGs