### PR TITLE
ci: fix linting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,10 @@ commands =
 [testenv:lint]
 basepython = python3
 deps=
-    ruff
-    mypy
+    ruff~=0.7.0
+    mypy~=1.12.0
 commands =
-    ruff src/bytecode tests
-    ruff format --check src/bytecode tests
+    ruff check src/bytecode tests
     mypy src tests
 
 [testenv:docs]


### PR DESCRIPTION
We fix the linting command by using the new ruff command. We also pin the tox linting environment dependencies to prevent the CI job from breaking again in the future.