### PR TITLE
Fix flag inference

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,13 @@
 ChangeLog
 =========
 
+unreleased: Version 0.16.1
+--------------------------
+
+Bugfixes:
+
+- fix flag inference for async code PR #157
+
 
 2024-10-28: Version 0.16.0
 --------------------------

--- a/src/bytecode/cfg.py
+++ b/src/bytecode/cfg.py
@@ -58,7 +58,7 @@ class BasicBlock(_bytecode._InstrList[Union[Instr, SetLineno, TryBegin, TryEnd]]
                     isinstance(self[i], Instr) for i in range(index, len(self))
                 ):
                     raise ValueError(
-                        "Only the last instruction of a basic " "block can be a jump"
+                        "Only the last instruction of a basic block can be a jump"
                     )
 
                 if not isinstance(instr.arg, BasicBlock):

--- a/src/bytecode/flags.py
+++ b/src/bytecode/flags.py
@@ -107,7 +107,6 @@ def infer_flags(
     known_generator = False
     possible_generator = False
     instr_iter = iter(instructions)
-    print()
     for instr in instr_iter:
         if isinstance(
             instr,

--- a/src/bytecode/flags.py
+++ b/src/bytecode/flags.py
@@ -57,15 +57,10 @@ ASYNC_OPCODES = (
 YIELD_VALUE_OPCODE = _opcode.opmap["YIELD_VALUE"]
 GENERATOR_LIKE_OPCODES = (
     *((_opcode.opmap["YIELD_FROM"],) if not PY311 else ()),  # Removed in 3.11+
-    _opcode.opmap["RETURN_GENERATOR"],
+    *((_opcode.opmap["RETURN_GENERATOR"],) if PY311 else ()),  # Added in 3.11+
 )
 
 
-# XXX
-# - rely on cell/free vars presence for NOFREE due to 3.13 allowing those in
-#   places reserved to locals before
-# - inspect RESUME following YIELD_VALUE to determine if we are dealing with a
-#   generator on 3.11+
 def infer_flags(
     bytecode: Union[
         "_bytecode.Bytecode", "_bytecode.ConcreteBytecode", "_bytecode.ControlFlowGraph"

--- a/src/bytecode/flags.py
+++ b/src/bytecode/flags.py
@@ -1,10 +1,12 @@
-import opcode
-import sys
+import opcode as _opcode
 from enum import IntFlag
 from typing import Optional, Union
 
 # alias to keep the 'bytecode' variable free
 import bytecode as _bytecode
+
+from .instr import DUAL_ARG_OPCODES, CellVar, FreeVar
+from .utils import PY311, PY312, PY313
 
 
 class CompilerFlags(IntFlag):
@@ -32,16 +34,38 @@ class CompilerFlags(IntFlag):
     # Generator defined in an async def function
     ASYNC_GENERATOR = 0x00200
 
-    # __future__ flags
-    # future flags changed in Python 3.9
-    if sys.version_info < (3, 9):
-        FUTURE_GENERATOR_STOP = 0x80000
-        FUTURE_ANNOTATIONS = 0x100000
-    else:
-        FUTURE_GENERATOR_STOP = 0x800000
-        FUTURE_ANNOTATIONS = 0x1000000
+    FUTURE_GENERATOR_STOP = 0x800000
+    FUTURE_ANNOTATIONS = 0x1000000
 
 
+UNOPTIMIZED_OPCODES = (
+    _opcode.opmap["STORE_NAME"],
+    _opcode.opmap["LOAD_NAME"],
+    _opcode.opmap["DELETE_NAME"],
+)
+
+ASYNC_OPCODES = (
+    _opcode.opmap["GET_AWAITABLE"],
+    _opcode.opmap["GET_AITER"],
+    _opcode.opmap["GET_ANEXT"],
+    _opcode.opmap["BEFORE_ASYNC_WITH"],
+    *((_opcode.opmap["SETUP_ASYNC_WITH"],) if not PY311 else ()),  # Removed in 3.11+
+    _opcode.opmap["END_ASYNC_FOR"],
+    *((_opcode.opmap["ASYNC_GEN_WRAP"],) if PY311 and not PY312 else ()),  # New in 3.11
+)
+
+YIELD_VALUE_OPCODE = _opcode.opmap["YIELD_VALUE"]
+GENERATOR_LIKE_OPCODES = (
+    *((_opcode.opmap["YIELD_FROM"],) if not PY311 else ()),  # Removed in 3.11+
+    _opcode.opmap["RETURN_GENERATOR"],
+)
+
+
+# XXX
+# - rely on cell/free vars presence for NOFREE due to 3.13 allowing those in
+#   places reserved to locals before
+# - inspect RESUME following YIELD_VALUE to determine if we are dealing with a
+#   generator on 3.11+
 def infer_flags(
     bytecode: Union[
         "_bytecode.Bytecode", "_bytecode.ConcreteBytecode", "_bytecode.ControlFlowGraph"
@@ -70,8 +94,7 @@ def infer_flags(
         (_bytecode.Bytecode, _bytecode.ConcreteBytecode, _bytecode.ControlFlowGraph),
     ):
         msg = (
-            "Expected a Bytecode, ConcreteBytecode or ControlFlowGraph "
-            "instance not %s"
+            "Expected a Bytecode, ConcreteBytecode or ControlFlowGraph instance not %s"
         )
         raise ValueError(msg % bytecode)
 
@@ -80,26 +103,74 @@ def infer_flags(
         if isinstance(bytecode, _bytecode.ControlFlowGraph)
         else bytecode
     )
-    instr_names = {
-        i.name
-        for i in instructions
-        if not isinstance(
-            i,
+
+    # Iterate over the instructions and inspect the arguments
+    is_concrete = isinstance(bytecode, _bytecode.ConcreteBytecode)
+    optimized = True
+    has_free = False if not is_concrete else bytecode.cellvars and bytecode.freevars
+    known_async = False
+    known_generator = False
+    possible_generator = False
+    instr_iter = iter(instructions)
+    print()
+    for instr in instr_iter:
+        if isinstance(
+            instr,
             (
                 _bytecode.SetLineno,
                 _bytecode.Label,
                 _bytecode.TryBegin,
                 _bytecode.TryEnd,
             ),
-        )
-    }
+        ):
+            continue
+        opcode = instr.opcode
+        if opcode in UNOPTIMIZED_OPCODES:
+            optimized = False
+        elif opcode in ASYNC_OPCODES:
+            known_async = True
+        elif opcode == YIELD_VALUE_OPCODE:
+            if PY311:
+                while isinstance(
+                    ni := next(instr_iter),
+                    (
+                        _bytecode.SetLineno,
+                        _bytecode.Label,
+                        _bytecode.TryBegin,
+                        _bytecode.TryEnd,
+                    ),
+                ):
+                    pass
+                assert ni.name == "RESUME"
+                if (ni.arg & 3) != 3:
+                    known_generator = True
+                else:
+                    known_async = True
+            else:
+                known_generator = True
+        elif opcode in GENERATOR_LIKE_OPCODES:
+            possible_generator = True
+        elif opcode in _opcode.hasfree:
+            has_free = True
+        elif (
+            not is_concrete
+            and opcode in DUAL_ARG_OPCODES
+            and (isinstance(instr.arg[0], CellVar) or isinstance(instr.arg[1], CellVar))
+        ):
+            has_free = True
+        elif (
+            PY313
+            and opcode in _opcode.haslocal
+            and isinstance(instr.arg, (CellVar, FreeVar))
+        ):
+            has_free = True
 
     # Identify optimized code
-    if not (instr_names & {"STORE_NAME", "LOAD_NAME", "DELETE_NAME"}):
+    if optimized:
         flags |= CompilerFlags.OPTIMIZED
 
     # Check for free variables
-    if not (instr_names & {opcode.opname[i] for i in opcode.hasfree}):
+    if not has_free:
         flags |= CompilerFlags.NOFREE
 
     # Copy flags for which we cannot infer the right value
@@ -110,29 +181,19 @@ def infer_flags(
         | CompilerFlags.NESTED
     )
 
-    sure_generator = instr_names & {"YIELD_VALUE"}
-    maybe_generator = instr_names & {"YIELD_VALUE", "YIELD_FROM", "RETURN_GENERATOR"}
-
-    sure_async = instr_names & {
-        "GET_AWAITABLE",
-        "GET_AITER",
-        "GET_ANEXT",
-        "BEFORE_ASYNC_WITH",
-        "SETUP_ASYNC_WITH",
-        "END_ASYNC_FOR",
-        "ASYNC_GEN_WRAP",  # New in 3.11
-    }
-
     # If performing inference or forcing an async behavior, first inspect
     # the flags since this is the only way to identify iterable coroutines
     if is_async in (None, True):
-        if bytecode.flags & CompilerFlags.COROUTINE:
-            if sure_generator:
+        if (
+            bytecode.flags & CompilerFlags.COROUTINE
+            or bytecode.flags & CompilerFlags.ASYNC_GENERATOR
+        ):
+            if known_generator:
                 flags |= CompilerFlags.ASYNC_GENERATOR
             else:
                 flags |= CompilerFlags.COROUTINE
         elif bytecode.flags & CompilerFlags.ITERABLE_COROUTINE:
-            if sure_async:
+            if known_async:
                 msg = (
                     "The ITERABLE_COROUTINE flag is set but bytecode that"
                     "can only be used in async functions have been "
@@ -141,25 +202,20 @@ def infer_flags(
                 )
                 raise ValueError(msg)
             flags |= CompilerFlags.ITERABLE_COROUTINE
-        elif bytecode.flags & CompilerFlags.ASYNC_GENERATOR:
-            if not sure_generator:
-                flags |= CompilerFlags.COROUTINE
-            else:
-                flags |= CompilerFlags.ASYNC_GENERATOR
 
         # If the code was not asynchronous before determine if it should now be
         # asynchronous based on the opcode and the is_async argument.
         else:
-            if sure_async:
+            if known_async:
                 # YIELD_FROM is not allowed in async generator
-                if sure_generator:
+                if known_generator:
                     flags |= CompilerFlags.ASYNC_GENERATOR
                 else:
                     flags |= CompilerFlags.COROUTINE
 
-            elif maybe_generator:
+            elif known_generator or possible_generator:
                 if is_async:
-                    if sure_generator:
+                    if known_generator:
                         flags |= CompilerFlags.ASYNC_GENERATOR
                     else:
                         flags |= CompilerFlags.COROUTINE
@@ -172,14 +228,14 @@ def infer_flags(
     # If the code should not be asynchronous, check first it is possible and
     # next set the GENERATOR flag if relevant
     else:
-        if sure_async:
+        if known_async:
             raise ValueError(
                 "The is_async argument is False but bytecodes "
                 "that can only be used in async functions have "
                 "been detected."
             )
 
-        if maybe_generator:
+        if known_generator or possible_generator:
             flags |= CompilerFlags.GENERATOR
 
     flags |= bytecode.flags & CompilerFlags.FUTURE_GENERATOR_STOP

--- a/src/bytecode/instr.py
+++ b/src/bytecode/instr.py
@@ -269,13 +269,12 @@ class FreeVar(_Variable):
 def _check_arg_int(arg: Any, name: str) -> TypeGuard[int]:
     if not isinstance(arg, int):
         raise TypeError(
-            "operation %s argument must be an int, "
-            "got %s" % (name, type(arg).__name__)
+            "operation %s argument must be an int, got %s" % (name, type(arg).__name__)
         )
 
     if not (0 <= arg <= 2147483647):
         raise ValueError(
-            "operation %s argument must be in " "the range 0..2,147,483,647" % name
+            "operation %s argument must be in the range 0..2,147,483,647" % name
         )
 
     return True
@@ -900,13 +899,9 @@ class Instr(BaseInstr[InstrArg]):
 
         elif opcode in _opcode.hasconst:
             if isinstance(arg, Label):
-                raise ValueError(
-                    "label argument cannot be used " "in %s operation" % name
-                )
+                raise ValueError("label argument cannot be used in %s operation" % name)
             if isinstance(arg, _bytecode.BasicBlock):
-                raise ValueError(
-                    "block argument cannot be used " "in %s operation" % name
-                )
+                raise ValueError("block argument cannot be used in %s operation" % name)
 
         elif opcode in _opcode.hascompare:
             if not isinstance(arg, Compare):

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -668,18 +668,12 @@ class BytecodeBlocksFunctionalTests(TestCase):
             )
         elif PY311:
             # jump is relative not absolute
-            expected = (
-                b"|\x05" b"r\x02" b"|\x00" b"}\x05" b"d\x01" b"}\x05" b"|\x05" b"S\x00"
-            )
+            expected = b"|\x05r\x02|\x00}\x05d\x01}\x05|\x05S\x00"
         elif OFFSET_AS_INSTRUCTION:
             # The argument of the jump is divided by 2
-            expected = (
-                b"|\x05" b"r\x04" b"|\x00" b"}\x05" b"d\x01" b"}\x05" b"|\x05" b"S\x00"
-            )
+            expected = b"|\x05r\x04|\x00}\x05d\x01}\x05|\x05S\x00"
         else:
-            expected = (
-                b"|\x05" b"r\x08" b"|\x00" b"}\x05" b"d\x01" b"}\x05" b"|\x05" b"S\x00"
-            )
+            expected = b"|\x05r\x08|\x00}\x05d\x01}\x05|\x05S\x00"
 
         code = bytecode.to_code()
         self.assertEqual(code.co_consts, (None, 3))

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -111,7 +111,10 @@ class FlagsTests(unittest.TestCase):
                     # NOTE: as far as I can tell NOFREE is not used by CPython anymore
                     # it shows up nowhere in the interpreter logic and only exist in
                     # dis and inspect...
-                    self.assertEqual(existing, b.flags & ~CompilerFlags.NOFREE)
+                    self.assertEqual(
+                        existing & ~CompilerFlags.NOFREE,
+                        b.flags & ~CompilerFlags.NOFREE,
+                    )
 
     def test_async_gen_no_flag_is_async_None(self):
         # Test inference in the absence of any flag set on the bytecode
@@ -138,7 +141,9 @@ class FlagsTests(unittest.TestCase):
         for i, r, expected in (
             ("YIELD_VALUE", 1, CompilerFlags.ASYNC_GENERATOR),
             ("YIELD_VALUE", 2, CompilerFlags.ASYNC_GENERATOR),
-            ("YIELD_VALUE", 3, CompilerFlags.COROUTINE),
+            # YIELD_VALUE is used for normal await flow in Py 3.11+ when followed
+            # by a RESUME whose lowest two bits are set to 3
+            *((("YIELD_VALUE", 3, CompilerFlags.COROUTINE),) if PY311 else ()),
             ("YIELD_FROM", 0, CompilerFlags.COROUTINE),
         ):
             with self.subTest(i):
@@ -164,7 +169,9 @@ class FlagsTests(unittest.TestCase):
         for i, r, expected in (
             ("YIELD_VALUE", 1, CompilerFlags.ASYNC_GENERATOR),
             ("YIELD_VALUE", 2, CompilerFlags.ASYNC_GENERATOR),
-            ("YIELD_VALUE", 3, CompilerFlags.COROUTINE),
+            # YIELD_VALUE is used for normal await flow in Py 3.11+ when followed
+            # by a RESUME whose lowest two bits are set to 3
+            *((("YIELD_VALUE", 3, CompilerFlags.COROUTINE),) if PY311 else ()),
             ("YIELD_FROM", 0, CompilerFlags.COROUTINE),
         ):
             with self.subTest(i):


### PR DESCRIPTION
Starting with Python 3.11, YIELD_VALUE appears in async function using await even if the function is not a generator. To identify if a YIELD_VALUE is associated with a generator like behavior one needs to inspect the argument of the following RESUME which was not done.

The new logic should be more robust and several round-trip test have been added to ensure we do not promote coroutine to async generator for no reason.

Closes #155