### PR TITLE
cfg: fix dead block detection by accounting for fall-through edges

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,14 @@
 ChangeLog
 =========
 
+2025-04-14: Version 0.16.2
+--------------------------
+
+Bugfixes:
+
+- fix ControlFlowGraph dead block detection by accounting for fall-through
+  edges. PR #161
+
 2025-01-21: Version 0.16.1
 --------------------------
 

--- a/src/bytecode/cfg.py
+++ b/src/bytecode/cfg.py
@@ -731,12 +731,18 @@ class ControlFlowGraph(_bytecode.BaseBytecode):
             if id(block) in seen_block_ids:
                 continue
             seen_block_ids.add(id(block))
+            fall_through = True
             for i in block:
-                if isinstance(i, Instr) and isinstance(i.arg, BasicBlock):
-                    stack.append(i.arg)
+                if isinstance(i, Instr):
+                    if isinstance(i.arg, BasicBlock):
+                        stack.append(i.arg)
+                    if i.is_final():
+                        fall_through = False
                 elif isinstance(i, TryBegin):
                     assert isinstance(i.target, BasicBlock)
                     stack.append(i.target)
+            if fall_through and block.next_block:
+                stack.append(block.next_block)
 
         return [b for b in self if id(b) not in seen_block_ids]
 

--- a/tests/test_cfg.py
+++ b/tests/test_cfg.py
@@ -712,6 +712,20 @@ class BytecodeBlocksFunctionalTests(TestCase):
         other_block = BasicBlock()
         self.assertRaises(ValueError, blocks.get_block_index, other_block)
 
+    def test_get_dead_blocks(self):
+        def condition():
+            pass
+
+        def test():
+            if condition():
+                print("1")
+            else:
+                print("2")
+
+        bytecode = Bytecode.from_code(test.__code__)
+        cfg = ControlFlowGraph.from_bytecode(bytecode)
+        assert len(cfg.get_dead_blocks()) == 0
+
 
 class CFGStacksizeComputationTests(TestCase):
     def check_stack_size(self, func):


### PR DESCRIPTION
Previously, the `get_dead_blocks` method of `ControlFlowGraph` did not consider basic blocks connected via fall-through edges `block.next_block` when traversing the control flow graph. [Current implementation](https://github.com/MatthieuDartiailh/bytecode/blob/b3daaaa13efbedf2a46a3c6a433bf658bf2d3680/src/bytecode/cfg.py#L723) led to incorrect identification of dead blocks in cases where sequential execution flows into subsequent blocks without explicit branch instructions, as an example:

```python
    def test_get_dead_blocks(self):
        def condition():
            pass

        def test():
            if condition():
                print("1")
            else:
                print("2")

        bytecode = Bytecode.from_code(test.__code__) 
        cfg = ControlFlowGraph.from_bytecode(bytecode)
        assert len(cfg.get_dead_blocks()) == 0 # <--- current implementation would fail here
```

The fix updates the CFG traversal logic to:

1. **DFS** traversal starting from the first block
2. **Tracking visited blocks** using a set (seen_block_ids)
3. **Processing instructions:**
     -  Following branch targets (if `Instr` with `BasicBlock` arg)
     -  Skipping fall-through if a final instruction is found (`i.is_final()`)
     -  Handling `TryBegin` by pushing its target block
4. **Adding fall-through blocks** (`block.next_block`) if no final instruction was encountered

This ensures only unreachable blocks remain unvisited.

Add test cases for CFG traversal with fall-through scenarios.