### PR TITLE
cfg: fix stack depth of TryBegin when splitting across blocks.

### DIFF
--- a/src/bytecode/cfg.py
+++ b/src/bytecode/cfg.py
@@ -871,9 +871,7 @@ class ControlFlowGraph(_bytecode.BaseBytecode):
                     #   the new one since the blocks are disconnected.
                     if last_instr.is_final() and temp:
                         old_block.append(TryEnd(try_begins[active_try_begin][-1]))
-                        new_tb = TryBegin(
-                            active_try_begin.target, active_try_begin.push_lasti
-                        )
+                        new_tb = active_try_begin.copy()
                         block.append(new_tb)
                         # Add this new TryBegin to the map to properly update
                         # the target.


### PR DESCRIPTION
When constructing the `ControlFlowGraph` from `Bytecode`, current implementation would split instructions into `BasicBlock` when encountering a **final** instruction. If the split point is inside a `TryBegin`/`TryEnd` pair, it will yield multiple copies of `TryBegin` and `TryEnd` instances for the generated blocks. However, currently the implementation does not set the `stack_depth` filed of the `TryBegin` copies, as in the [source](https://github.com/MatthieuDartiailh/bytecode/blob/0.16.2/src/bytecode/cfg.py#L875).