### PR TITLE
Replace string-based references with postponed evaluation (PEP 563)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,8 @@ unreleased: Version 0.18.0
 --------------------------
 
 - drop support for Python 3.9 and 3.10 PR #180
+- Replace string literal type annotations with postponed evaluation using
+  ``from __future__ import annotations`` PR #191
 
 Bugfixes:
 

--- a/src/bytecode/bytecode.py
+++ b/src/bytecode/bytecode.py
@@ -1,4 +1,3 @@
-# alias to keep the 'bytecode' variable free
 import types
 from abc import abstractmethod
 from typing import (
@@ -15,6 +14,7 @@ from typing import (
     overload,
 )
 
+# alias to keep the 'bytecode' variable free
 import bytecode as _bytecode
 from bytecode.flags import CompilerFlags, infer_flags
 from bytecode.instr import (

--- a/src/bytecode/bytecode.py
+++ b/src/bytecode/bytecode.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import types
 from abc import abstractmethod
 from typing import (
@@ -48,7 +50,7 @@ class BaseBytecode:
         self.freevars: List[str] = []
         self._flags: CompilerFlags = CompilerFlags(0)
 
-    def _copy_attr_from(self, bytecode: "BaseBytecode") -> None:
+    def _copy_attr_from(self, bytecode: BaseBytecode) -> None:
         self.argcount = bytecode.argcount
         self.posonlyargcount = bytecode.posonlyargcount
         self.kwonlyargcount = bytecode.kwonlyargcount
@@ -275,7 +277,7 @@ class Bytecode(
         code: types.CodeType,
         prune_caches: bool = True,
         conserve_exception_block_stackdepth: bool = False,
-    ) -> "Bytecode":
+    ) -> Bytecode:
         concrete = _bytecode.ConcreteBytecode.from_code(code)
         return concrete.to_bytecode(
             prune_caches=prune_caches,
@@ -317,7 +319,7 @@ class Bytecode(
         self,
         compute_jumps_passes: Optional[int] = None,
         compute_exception_stack_depths: bool = True,
-    ) -> "_bytecode.ConcreteBytecode":
+    ) -> _bytecode.ConcreteBytecode:
         converter = _bytecode._ConvertBytecodeToConcrete(self)
         return converter.to_concrete_bytecode(
             compute_jumps_passes=compute_jumps_passes,

--- a/src/bytecode/cfg.py
+++ b/src/bytecode/cfg.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import types
 from collections import defaultdict
 from dataclasses import dataclass
@@ -36,7 +38,7 @@ class BasicBlock(_bytecode._InstrList[Union[Instr, SetLineno, TryBegin, TryEnd]]
         ] = None,
     ) -> None:
         # a BasicBlock object, or None
-        self.next_block: Optional["BasicBlock"] = None
+        self.next_block: Optional[BasicBlock] = None
         if instructions:
             super().__init__(instructions)
 
@@ -129,7 +131,7 @@ class BasicBlock(_bytecode._InstrList[Union[Instr, SetLineno, TryBegin, TryEnd]]
 
         return current_lineno
 
-    def get_jump(self) -> Optional["BasicBlock"]:
+    def get_jump(self) -> Optional[BasicBlock]:
         if not self:
             return None
 
@@ -243,7 +245,7 @@ class _StackSizeComputer:
         self.pending_try_begin = pending_try_begin
         self._current_try_begin = pending_try_begin
 
-    def run(self) -> Generator[Union["_StackSizeComputer", int], int, None]:
+    def run(self) -> Generator[Union[_StackSizeComputer, int], int, None]:
         """Iterate over the block instructions to compute stack usage."""
         # Blocks are not hashable but in this particular context we know we won't be
         # modifying blocks in place so we can safely use their id as hash rather than
@@ -430,7 +432,7 @@ class _StackSizeComputer:
 
     def _compute_exception_handler_stack_usage(
         self, block: BasicBlock, push_lasti: bool
-    ) -> Generator[Union["_StackSizeComputer", int], int, None]:
+    ) -> Generator[Union[_StackSizeComputer, int], int, None]:
         b_id = id(block)
         if self.minsize < self.common.exception_block_startsize[b_id]:
             block_size = yield _StackSizeComputer(
@@ -741,7 +743,7 @@ class ControlFlowGraph(_bytecode.BaseBytecode):
         return [b for b in self if id(b) not in seen_block_ids]
 
     @staticmethod
-    def from_bytecode(bytecode: _bytecode.Bytecode) -> "ControlFlowGraph":
+    def from_bytecode(bytecode: _bytecode.Bytecode) -> ControlFlowGraph:
         # label => instruction index
         label_to_block_index = {}
         jumps = []

--- a/src/bytecode/concrete.py
+++ b/src/bytecode/concrete.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dis
 import inspect
 import itertools
@@ -332,7 +334,7 @@ class ConcreteBytecode(_bytecode._BaseBytecodeList[Union[ConcreteInstr, SetLinen
     @staticmethod
     def from_code(
         code: types.CodeType, *, extended_arg: bool = False
-    ) -> "ConcreteBytecode":
+    ) -> ConcreteBytecode:
         instructions: MutableSequence[Union[SetLineno, ConcreteInstr]] = []
         for i in dis.get_instructions(code, show_caches=True):
             loc = InstrLocation.from_positions(i.positions) if i.positions else None

--- a/src/bytecode/instr.py
+++ b/src/bytecode/instr.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dis
 import enum
 import opcode as _opcode
@@ -267,7 +269,7 @@ class CommonConstant(enum.IntEnum):
 # This make type checking happy but means it won't catch attempt to manipulate an unset
 # statically. We would need guard on object attribute narrowed down through methods
 class _UNSET(int):
-    instance: Optional["_UNSET"] = None
+    instance: Optional[_UNSET] = None
 
     def __new__(cls):
         if cls.instance is None:
@@ -611,7 +613,7 @@ class InstrLocation:
                 )
 
     @classmethod
-    def from_positions(cls, position: "dis.Positions") -> "InstrLocation":  # type: ignore
+    def from_positions(cls, position: dis.Positions) -> InstrLocation:  # type: ignore
         return InstrLocation(
             position.lineno,
             position.end_lineno,
@@ -654,7 +656,7 @@ class TryBegin:
         self.push_lasti: bool = push_lasti
         self.stack_depth: int | _UNSET = stack_depth
 
-    def copy(self) -> "TryBegin":
+    def copy(self) -> TryBegin:
         return TryBegin(self.target, self.push_lasti, self.stack_depth)
 
 
@@ -664,7 +666,7 @@ class TryEnd:
     def __init__(self, entry: TryBegin) -> None:
         self.entry: TryBegin = entry
 
-    def copy(self) -> "TryEnd":
+    def copy(self) -> TryEnd:
         return TryEnd(self.entry)
 
 

--- a/tests/frameworks/module.py
+++ b/tests/frameworks/module.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import abc
 import sys
 import typing as t
@@ -124,7 +126,7 @@ class BaseModuleWatchdog:
     Invokes ``after_import`` every time a new module is imported.
     """
 
-    _instance: t.Optional["BaseModuleWatchdog"] = None
+    _instance: t.Optional[BaseModuleWatchdog] = None
 
     def __init__(self) -> None:
         self._finding: t.Set[str] = set()


### PR DESCRIPTION
This PR replaces string literal type annotations with postponed evaluation ([PEP 563](https://peps.python.org/pep-0563/)) for cleaner and more modern typing using:
```py
from __future__ import annotations
```