### PR TITLE
perf: avoid redundant validation in copy() and __iter__

### DIFF
--- a/src/bytecode/bytecode.py
+++ b/src/bytecode/bytecode.py
@@ -164,12 +164,6 @@ class _BaseBytecodeList(BaseBytecode, list, Generic[U]):
         for i in reversed(lineno_pos):
             del self[i]
 
-    def __iter__(self) -> Iterator[U]:
-        instructions = super().__iter__()
-        for instr in instructions:
-            self._check_instr(instr)
-            yield instr
-
     def _check_instr(self, instr):
         raise NotImplementedError()
 

--- a/src/bytecode/instr.py
+++ b/src/bytecode/instr.py
@@ -812,7 +812,12 @@ class BaseInstr(Generic[A]):
             return (_effect, 0)
 
     def copy(self: T) -> T:
-        return self.__class__(self._name, self._arg, location=self._location)
+        new = object.__new__(self.__class__)
+        new._name = self._name
+        new._opcode = self._opcode
+        new._arg = self._arg
+        new._location = self._location
+        return new
 
     def has_jump(self) -> bool:
         return self._has_jump(self._opcode)


### PR DESCRIPTION
`BaseInstr.copy()` previously reconstructed instructions via `__init__`, triggering the full `_set → _check_arg` validation chain on every copy even though the source instruction is already known to be valid. Replace with `object.__new__` + direct slot assignment to bypass validation entirely.

`_BaseBytecodeList.__iter__` ran `_check_instr` on every yielded item, but `Bytecode.__iter__` (which calls this via `super()`) was already doing the same check — a redundant double-validation on every iteration.

The script used for validating the change does a round-trip decompile/recompile for 1 second:

```python
from time import perf_counter_ns as time

def test_roundtrip(code_object):
    end = time() + 1e9  # 1 second
    c = 0
    while time() < end:
        c += 1
        Bytecode.from_code(code_object).to_code()
    print(f"{code_object.co_name!r}: {c} round-trips/s")
```

Profiling shows the following own CPU time figures:

| Function | Before | After | Relative change |
| --- | --- | --- | --- |
| `Instr._check_arg` |7.85% | 3.13% | −4.72% |
| `BaseInstr._set` | 2.57% | 1.37% | −1.20% |
| `_BaseBytecodeList.__iter__` | 2.18% | 0.0% | -2.18% |

Throughput (number of iteration within the 1 second duration) goes from ~90 to ~105.