### PR TITLE
perf: bypass ConcreteInstr validation in from_code via _from_opcode

### DIFF
--- a/src/bytecode/concrete.py
+++ b/src/bytecode/concrete.py
@@ -182,6 +182,24 @@ class ConcreteInstr(BaseInstr[int]):
         return bytes(b)
 
     @classmethod
+    def _from_opcode(
+        cls: Type[T],
+        name: str,
+        opcode: int,
+        arg: int,
+        location: Optional[InstrLocation],
+    ) -> T:
+        """Fast path for from_code: arg is a raw byte (0-255), size is always 2."""
+        new = object.__new__(cls)
+        new._name = name
+        new._opcode = opcode
+        new._arg = arg
+        new._location = location
+        new._extended_args = None
+        new._size = 2
+        return new
+
+    @classmethod
     def disassemble(cls: Type[T], lineno: Optional[int], code: bytes, offset: int) -> T:
         index = 2 * offset
         op = code[index]
@@ -353,7 +371,7 @@ class ConcreteBytecode(_bytecode._BaseBytecodeList[Union[ConcreteInstr, SetLinen
             loc: Optional[InstrLocation] = (
                 InstrLocation._from_tuple(*pos) if pos is not None else None
             )
-            instructions.append(ConcreteInstr(opname[op], arg, location=loc))
+            instructions.append(ConcreteInstr._from_opcode(opname[op], op, arg, loc))
 
         bytecode = ConcreteBytecode()
 


### PR DESCRIPTION
Add ConcreteInstr._from_opcode, a fast-path constructor for the from_code loop that skips all validation and sets the six slots directly via object.__new__ + attribute assignment.

The checks are safe to skip because every instruction in this path comes from CPython's own co_code bytes:
- name/opcode: _opcode.opname[byte] is always a valid opcode
- arg: a raw byte (0-255), always satisfies _check_arg_int, or UNSET for no-argument opcodes (already gated by opcode_has_argument)
- _size: always 2 — EXTENDED_ARG accumulation happens after this loop in _remove_extended_args, not during construction
- _extended_args: always None in this path

CPU profiling data (where the impact is more visible):

| Hotspot | Before | After |
|---|---|---|
| `ConcreteInstr.__init__` own | 3.11% | eliminated | | `ConcreteInstr._set` own | 1.68% | eliminated |
| `ConcreteInstr._check_arg` own | 1.82% | eliminated | | `ConcreteInstr._from_opcode` own | — | 2.77% |
| `ConcreteBytecode.from_code` own | 6.21% | 4.55% |

Throughput (usual Bytecode.from_code().to_code() round-trip, 1 second timed window, 5 runs):

| | r/s range |
|---|---|
| Before | ~143 |
| After | ~148 |