### PR TITLE
perf: cache size and jump_target from first pass in to_bytecode

### DIFF
--- a/src/bytecode/concrete.py
+++ b/src/bytecode/concrete.py
@@ -782,16 +782,19 @@ class ConcreteBytecode(_bytecode._BaseBytecodeList[Union[ConcreteInstr, SetLinen
         c_instructions = self[:]
         self._remove_extended_args(c_instructions)
 
-        # Find jump targets
+        # Find jump targets; stash (size, jump_target) to avoid recomputing in the main loop
         jump_targets: Set[int] = set()
+        _instr_props: List[Tuple[int, Optional[int]]] = []
         offset = 0
         for c_instr in c_instructions:
             if isinstance(c_instr, SetLineno):
                 continue
+            size = c_instr.size
             target = c_instr.get_jump_target(offset)
+            _instr_props.append((size, target))
             if target is not None:
                 jump_targets.add(target)
-            offset += c_instr.size // 2
+            offset += size // 2
 
         # On 3.11+ we need to also look at the exception table for jump targets
         for ex_entry in self.exception_table:
@@ -839,6 +842,7 @@ class ConcreteBytecode(_bytecode._BaseBytecodeList[Union[ConcreteInstr, SetLinen
         else:
             locals_lookup = self.varnames
 
+        _props_iter = iter(_instr_props)
         for lineno, c_instr in self._normalize_lineno(
             c_instructions, self.first_lineno
         ):
@@ -864,8 +868,7 @@ class ConcreteBytecode(_bytecode._BaseBytecodeList[Union[ConcreteInstr, SetLinen
                     tb_instrs[entry] = tb_instr
                     instructions.append(tb_instr)
 
-            jump_target = c_instr.get_jump_target(offset)
-            size = c_instr.size
+            size, jump_target = next(_props_iter)
             # If an instruction uses extended args, those appear before the instruction
             # causing the instruction to appear at offset that accounts for extended
             # args. So we first update the offset to account for extended args, then


### PR DESCRIPTION
`ConcreteBytecode.to_bytecode` makes two passes over the instruction list. The first pass (finding jump targets) already calls `c_instr.get_jump_target(offset)` and `c_instr.size` for every instruction. The main loop then called both again — redundantly, at the same offsets.

This change stashes `(size, jump_target)` per instruction into a list during the first pass and consumes it via an iterator in the main loop, eliminating all second calls to `get_jump_target` and `size`.

## Profiling data

| Hotspot | Before | After |
|---|---|---|
| `ConcreteBytecode.to_bytecode` own | 9.56% | 8.29% |
| `ConcreteBytecode.to_bytecode` total | 19.55% | 15.55% |
| `ConcreteInstr.get_jump_target` total | 2.74% | gone (< top 20) |
| `ConcreteInstr.size` total | 1.30% | gone (< top 20) |

## Benchmark runs

| | Range | Avg |
|---|---|---|
| Before | 214–226 r/s | ~221 r/s |
| After | 224–232 r/s | ~229 r/s |

~3.5% throughput improvement.